### PR TITLE
Fix patient update password handling

### DIFF
--- a/src/pages/PacientesPage.jsx
+++ b/src/pages/PacientesPage.jsx
@@ -84,7 +84,11 @@ export default function PacientesPage() {
     e.preventDefault();
     try {
       if (pacienteEditando) {
-        await actualizar(pacienteEditando.id, formData);
+        const dataToSend = { ...formData, usuario: { ...formData.usuario } };
+        if (!dataToSend.usuario.contraseña) {
+          delete dataToSend.usuario.contraseña;
+        }
+        await actualizar(pacienteEditando.id, dataToSend);
         alert("Paciente actualizado exitosamente");
       } else {
         await crear(formData);


### PR DESCRIPTION
## Summary
- keep password unchanged when editing a patient if the field is left blank
- ensure update handler copies nested user object to avoid mutating form state

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687b0067f174832f80e6362f127cdb03